### PR TITLE
(For legacy code) Make it work again, performance tweaks.

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -9,7 +9,7 @@
 ; https://docs.platformio.org/page/projectconf.html
 
 [env:esp12e]
-platform = espressif8266
+platform = espressif8266 @ ~2.6.3
 board = esp12e
 framework = arduino
 monitor_speed = 115200

--- a/platformio.ini
+++ b/platformio.ini
@@ -10,6 +10,9 @@
 
 [env:esp12e]
 platform = espressif8266 @ ~2.6.3
+board_build.f_cpu = 160000000L
+board_build.f_flash = 80000000L
+board_build.flash_mode = qio
 board = esp12e
 framework = arduino
 monitor_speed = 115200

--- a/src/BTT_TF_CLOUD_AFW.cpp
+++ b/src/BTT_TF_CLOUD_AFW.cpp
@@ -111,7 +111,7 @@ void setup()
 	Serial.println("--------------------------------");
 	Serial.println("Start FTP server");
 	Serial.println("--------------------------------");
-	ftpSrv.begin("anonymous", "", SD_CS, SPI_FULL_SPEED); //username, password for ftp.  set ports in ESP8266FtpServer.h  (default 21, 50009 for PASV)
+	ftpSrv.begin("anonymous", "", SD_CS, 40000000L); //username, password for ftp.  set ports in ESP8266FtpServer.h  (default 21, 50009 for PASV)
 	Serial.println("FTP server started");
 
 	// Setup FLASH button and LED
@@ -133,7 +133,7 @@ void loop()
 
 		// call handle if server was initialized properly
 
-		dav.initSD(SD_CS, SPI_FULL_SPEED);
+		dav.initSD(SD_CS, 40000000L);
 		dav.handleClient();
 	}
 

--- a/src/ESPWebDAV.cpp
+++ b/src/ESPWebDAV.cpp
@@ -261,7 +261,7 @@ void ESPWebDAV::handleProp(ResourceType resource)	{
 		// append children information to message
 		SdFile childFile;
 		while(childFile.openNext(&baseFile, O_READ)) {
-			yield();
+			delay(0);
 			sendPropResponse(true, &childFile);
 			childFile.close();
 		}

--- a/src/WebSrv.cpp
+++ b/src/WebSrv.cpp
@@ -112,7 +112,7 @@ void ESPWebDAV::processClient(THandlerFunction handler, String message) {
 
 	// Wait until the client sends some data
 	while(!client.available())
-		delay(1);
+		delay(0);
 	
 	// reset all variables
 	_chunked = false;
@@ -313,10 +313,10 @@ void ESPWebDAV::setContentLength(size_t len)	{
 // ------------------------
 size_t ESPWebDAV::readBytesWithTimeout(uint8_t *buf, size_t bufSize) {
 // ------------------------
-	int timeout_ms = HTTP_MAX_POST_WAIT;
+	unsigned long tout = millis();
 	size_t numAvailable = 0;
-	while(!(numAvailable = client.available()) && client.connected() && timeout_ms--) 
-		delay(1);
+	while(!(numAvailable = client.available()) && client.connected() && (millis()-tout<HTTP_MAX_POST_WAIT))
+		delay(0);
 
 	if(!numAvailable)
 		return 0;
@@ -328,11 +328,11 @@ size_t ESPWebDAV::readBytesWithTimeout(uint8_t *buf, size_t bufSize) {
 // ------------------------
 size_t ESPWebDAV::readBytesWithTimeout(uint8_t *buf, size_t bufSize, size_t numToRead) {
 // ------------------------
-	int timeout_ms = HTTP_MAX_POST_WAIT;
+	unsigned long tout = millis();
 	size_t numAvailable = 0;
 	
-	while(((numAvailable = client.available()) < numToRead) && client.connected() && timeout_ms--) 
-		delay(1);
+	while(((numAvailable = client.available()) < numToRead) && client.connected() && (millis()-tout<HTTP_MAX_POST_WAIT))
+		delay(0);
 
 	if(!numAvailable)
 		return 0;


### PR DESCRIPTION
Using esp8266 platform >2.6.3 won't build because sdfat library was updated and no longer compatible.
Fix: Specify esp8266 platform version so Platformio downloads the correct one.